### PR TITLE
ci: add fmt/clippy checks and cross-platform builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,32 @@
+name: Build
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        run: rustup toolchain install stable --profile minimal --no-self-update
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build
+        run: cargo build --workspace --no-default-features --features derive
+
+      - name: Build release
+        run: cargo build --workspace --release --no-default-features --features derive

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,12 +5,13 @@ on:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -28,6 +29,12 @@ jobs:
 
       - name: Cache Rust dependencies and tools
         uses: Swatinem/rust-cache@v2
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Run Clippy
+        run: cargo clippy --workspace --no-default-features --features derive -- -D warnings
 
       - name: Test
         run: 'cargo llvm-cov --workspace --no-default-features --features derive'


### PR DESCRIPTION
## Summary
  Improves CI/CD pipeline with code quality checks and cross-platform support.

## Changes
  - ✅ Add `cargo fmt --check` and `cargo clippy` to quality pipeline
  - ✅ Separate cross-platform builds (Windows/macOS) into dedicated workflow
  - ✅ Add `workflow_dispatch` for manual runs