### PR TITLE
Log audio errors and continue with muted audio scene

### DIFF
--- a/syrillian/src/engine/audio/mod.rs
+++ b/syrillian/src/engine/audio/mod.rs
@@ -1,38 +1,65 @@
 use kira::listener::ListenerHandle;
 use kira::track::{SpatialTrackBuilder, SpatialTrackHandle};
 use kira::{AudioManager, AudioManagerSettings, DefaultBackend, Tween};
+use log::error;
 use nalgebra::{Quaternion, Vector3};
 
-pub struct AudioScene {
+struct AudioSceneInner {
     manager: AudioManager<DefaultBackend>,
     listener: ListenerHandle,
 }
 
-impl Default for AudioScene {
-    fn default() -> Self {
-        let mut manager = AudioManager::new(AudioManagerSettings::default())
-            .expect("Failed to initialize audio manager");
+impl AudioSceneInner {
+    fn new() -> Option<Self> {
+        let mut manager = match AudioManager::new(AudioManagerSettings::default()) {
+            Ok(x) => x,
+            Err(e) => {
+                error!("Audio manager could not be initialized: {e} ({e:?})");
+                return None;
+            }
+        };
 
         let position = Vector3::zeros();
         let orientation = Quaternion::identity();
 
-        let listener = manager
-            .add_listener(position, orientation)
-            .expect("Failed to add audio listener");
+        let listener = match manager.add_listener(position, orientation) {
+            Ok(x) => x,
+            Err(e) => {
+                // So we technically have an audio manager but can't play anything. Fantastic.
+                error!("Failed to add audio listener: {e}");
+                return None;
+            }
+        };
 
-        Self { manager, listener }
+        Some(Self { manager, listener })
+    }
+}
+
+pub struct AudioScene {
+    inner: Option<AudioSceneInner>,
+}
+
+impl Default for AudioScene {
+    fn default() -> Self {
+        Self {
+            inner: AudioSceneInner::new(),
+        }
     }
 }
 
 impl AudioScene {
     pub fn set_receiver_position(&mut self, receiver_position: Vector3<f32>) {
-        self.listener
-            .set_position(receiver_position, Tween::default());
+        self.inner.as_mut().map(|this| {
+            this.listener
+                .set_position(receiver_position, Tween::default())
+        });
     }
 
     pub fn set_receiver_orientation(&mut self, receiver_orientation: Quaternion<f32>) {
-        self.listener
-            .set_orientation(receiver_orientation, Tween::default());
+        self.inner.as_mut().map(|this| {
+            this.listener
+                .set_orientation(receiver_orientation, Tween::default())
+        });
     }
 
     /// Returns none if the spatial track limit was reached
@@ -41,8 +68,10 @@ impl AudioScene {
         initial_position: Vector3<f32>,
         track: SpatialTrackBuilder,
     ) -> Option<SpatialTrackHandle> {
-        self.manager
-            .add_spatial_sub_track(self.listener.id(), initial_position, track)
-            .ok()
+        self.inner.as_mut().and_then(|this| {
+            this.manager
+                .add_spatial_sub_track(this.listener.id(), initial_position, track)
+                .ok()
+        })
     }
 }

--- a/syrillian/src/engine/audio/mod.rs
+++ b/syrillian/src/engine/audio/mod.rs
@@ -14,7 +14,7 @@ impl AudioSceneInner {
         let mut manager = match AudioManager::new(AudioManagerSettings::default()) {
             Ok(x) => x,
             Err(e) => {
-                error!("Audio manager could not be initialized: {e} ({e:?})");
+                error!("Audio manager could not be initialized: {e:?}");
                 return None;
             }
         };

--- a/syrillian/src/engine/audio/mod.rs
+++ b/syrillian/src/engine/audio/mod.rs
@@ -49,17 +49,17 @@ impl Default for AudioScene {
 
 impl AudioScene {
     pub fn set_receiver_position(&mut self, receiver_position: Vector3<f32>) {
-        self.inner.as_mut().map(|this| {
+        if let Some(this) = self.inner.as_mut() {
             this.listener
                 .set_position(receiver_position, Tween::default())
-        });
+        }
     }
 
     pub fn set_receiver_orientation(&mut self, receiver_orientation: Quaternion<f32>) {
-        self.inner.as_mut().map(|this| {
+        if let Some(this) = self.inner.as_mut() {
             this.listener
                 .set_orientation(receiver_orientation, Tween::default())
-        });
+        }
     }
 
     /// Returns none if the spatial track limit was reached


### PR DESCRIPTION
Handled currently by just wrapping the inner structure in an `Option`. Fixes #80.