### PR TITLE
Early support: Replace expect/unwrap with graceful error handling (a step towards achieving #65)

### DIFF
--- a/syrillian/src/engine/assets/mesh/mod.rs
+++ b/syrillian/src/engine/assets/mesh/mod.rs
@@ -159,14 +159,23 @@ impl StoreDefaults for Mesh {
         let unit_square = Mesh::builder(UNIT_SQUARE_VERT.to_vec()).build();
         store_add_checked!(store, HMesh::UNIT_SQUARE_ID, unit_square);
 
-        let unit_cube = Mesh::load_from_obj_slice(CUBE_OBJ).expect("Cube Mesh load failed");
+        let unit_cube = Mesh::load_from_obj_slice(CUBE_OBJ).unwrap_or_else(|_| {
+            log::error!("Cube Mesh load failed");
+            std::process::exit(1);
+        });
         store_add_checked!(store, HMesh::UNIT_CUBE_ID, unit_cube);
 
-        let debug_arrow =
-            Mesh::load_from_obj_slice(DEBUG_ARROW).expect("Debug Arrow Mesh load failed");
+        let debug_arrow = Mesh::load_from_obj_slice(DEBUG_ARROW).unwrap_or_else(|_| {
+            log::error!("Arrow Mesh load failed");
+            std::process::exit(1);
+        });
         store_add_checked!(store, HMesh::DEBUG_ARROW_ID, debug_arrow);
 
-        let sphere = Mesh::load_from_obj_slice(SPHERE).expect("Sphere Mesh load failed");
+        let sphere = Mesh::load_from_obj_slice(SPHERE).unwrap_or_else(|_| {
+            log::error!("Sphere Mesh load failed");
+            std::process::exit(1);
+        });
+
         store_add_checked!(store, HMesh::SPHERE_ID, sphere);
     }
 }

--- a/syrillian/src/engine/assets/scene_loader.rs
+++ b/syrillian/src/engine/assets/scene_loader.rs
@@ -300,7 +300,11 @@ fn load_mesh(scene: &GltfScene, node: Node) -> Option<(Mesh, Vec<u32>)> {
                     let t4 = t[vi as usize];
                     let t3 = Vector3::new(t4[0], t4[1], t4[2]);
                     tangents.push(t3);
-                    let n3 = *normals.last().unwrap();
+                    let n3 = *normals.last().unwrap_or_else(||
+                    {
+                        log::error!("Failed in deref normals.last in Scene_Loader.rs");
+                        std::process::exit(1);
+                    });
                     let b = n3.cross(&t3).normalize() * t4[3].signum();
                     bitangents.push(b);
                 } else {
@@ -504,7 +508,11 @@ fn animations_from_scene(scene: &GltfScene) -> Vec<AnimationClip> {
                 max_time = max_time.max(times.last().copied().unwrap_or(0.0));
 
                 let mut keys = TransformKeys::default();
-                match reader.read_outputs().expect("outputs") {
+                match reader.read_outputs().unwrap_or_else(||
+                {
+                log::error!("Failed while reading outputs in Scene_Loader.rs");
+                std::process::exit(1);
+                }) {
                     ReadOutputs::Translations(v) => {
                         let vals: Vec<[f32; 3]> = v.collect();
                         keys.t_times = times.clone();
@@ -632,7 +640,11 @@ where
 
     debug_assert_eq!(
         data.len(),
-        w as usize * h as usize * format.block_copy_size(None).unwrap() as usize
+        w as usize * h as usize * format.block_copy_size(None).unwrap_or_else(||
+                {
+                log::error!("Failed while debug_asserting the data.len()");
+                std::process::exit(1);
+                }) as usize
     );
 
     Some(Texture::load_pixels(data, w, h, TextureFormat::Rgba8UnormSrgb).store(world))

--- a/syrillian/src/engine/audio/mod.rs
+++ b/syrillian/src/engine/audio/mod.rs
@@ -10,15 +10,24 @@ pub struct AudioScene {
 
 impl Default for AudioScene {
     fn default() -> Self {
-        let mut manager = AudioManager::new(AudioManagerSettings::default())
-            .expect("Failed to initialize audio manager");
+        let mut manager = match AudioManager::new(AudioManagerSettings::default()) {
+            Ok(manager) => manager,
+            Err(e) => {
+                log::error!("Failed to initialize audio manager : {}", e);
+                std::process::exit(1);
+            }
+        };
 
         let position = Vector3::zeros();
         let orientation = Quaternion::identity();
 
-        let listener = manager
-            .add_listener(position, orientation)
-            .expect("Failed to add audio listener");
+        let listener = match manager.add_listener(position, orientation) {
+            Ok(listener) => listener,
+            Err(e) => {
+                log::error!("Failed to add audio listener : {}", e);
+                std::process::exit(1);
+            }
+        };
 
         Self { manager, listener }
     }

--- a/syrillian/src/engine/components/collider.rs
+++ b/syrillian/src/engine/components/collider.rs
@@ -102,7 +102,9 @@ impl Component for Collider3D {
         if let Some(body_comp) = body_comp {
             if self.linked_to_body.is_none() {
                 self.link_to_rigid_body(Some(body_comp.body_handle));
-                let coll = self.get_collider_mut().unwrap();
+                let coll = self.get_collider_mut()
+                    .unwrap_or_else(||{log::error!("get_collider_mut returned None");
+                    std::process::exit(1);});
                 coll.set_translation(Vector3::identity());
                 coll.set_rotation(Rotation::identity());
                 // TODO: Sync Scale to coll
@@ -111,7 +113,9 @@ impl Component for Collider3D {
             // the collider just takes on the parent transformations
             let translation = self.parent.transform.position();
             let rotation = self.parent.transform.rotation();
-            let coll = self.get_collider_mut().unwrap();
+            let coll = self.get_collider_mut()
+                .unwrap_or_else(||{log::error!("get_collider_mut returned None");
+                    std::process::exit(1);});
             coll.set_translation(translation);
             coll.set_rotation(rotation);
             // TODO: Sync Scale to coll

--- a/syrillian/src/engine/components/mod.rs
+++ b/syrillian/src/engine/components/mod.rs
@@ -140,7 +140,10 @@ impl<C: Component> Deref for CRef<C> {
         World::instance()
             .components
             .get(CRef(self.0, PhantomData))
-            .unwrap()
+            .unwrap_or_else(|| {
+                log::error!("Error getting a PhantomData in the CRef implementation");
+                std::process::exit(1);
+            })
     }
 }
 
@@ -149,7 +152,12 @@ impl<C: Component> DerefMut for CRef<C> {
         World::instance()
             .components
             .get_mut(CRef(self.0, PhantomData))
-            .unwrap()
+            .unwrap_or_else(|| {
+                log::error!(
+                    "Error getting a mutable PhantomData in the mutable CRef implementation"
+                );
+                std::process::exit(1);
+            })
     }
 }
 

--- a/syrillian/src/engine/components/rigid_body.rs
+++ b/syrillian/src/engine/components/rigid_body.rs
@@ -100,7 +100,10 @@ impl RigidBodyComponent {
     }
 
     pub fn set_kinematic(&mut self, kinematic: bool) {
-        let rb = self.get_body_mut().expect("Rigid body de-synced");
+        let rb = self.get_body_mut().unwrap_or_else(|| {
+            log::error!("Rigid body de-synced");
+            std::process::exit(1);
+        });
         if kinematic {
             rb.set_body_type(RigidBodyType::KinematicPositionBased, false);
         } else {

--- a/syrillian/src/engine/core/component_storage.rs
+++ b/syrillian/src/engine/core/component_storage.rs
@@ -94,7 +94,10 @@ impl ComponentStorage {
             ._get_from_id(tid)?
             .as_dyn()
             .downcast_ref::<HopSlotMap<ComponentId, C>>()
-            .expect("Type ID was checked");
+            .unwrap_or_else(|| {
+                log::error!("The checking of a type ID resulted in an error with _get");
+                std::process::exit(1);
+            });
 
         Some(typed)
     }
@@ -106,7 +109,10 @@ impl ComponentStorage {
             ._get_mut_from_id(tid)?
             .as_dyn_mut()
             .downcast_mut::<HopSlotMap<ComponentId, C>>()
-            .expect("Type ID was checked");
+            .unwrap_or_else(|| {
+                log::error!("The checking of a type ID resulted in an error with _get_mut");
+                std::process::exit(1);
+            });
 
         Some(typed)
     }
@@ -166,7 +172,10 @@ impl ComponentStorage {
             .or_insert_with(|| Box::new(HopSlotMap::<ComponentId, C>::with_key()))
             .as_dyn_mut()
             .downcast_mut()
-            .unwrap()
+            .unwrap_or_else(|| {
+                log::error!("An error was encountered while trying to get a mutable ref to an HopSlotMap for the components IDs");
+                std::process::exit(1);
+            })
     }
 
     pub(crate) fn add<C: Component>(&mut self, component: C) -> CRef<C> {

--- a/syrillian/src/engine/core/object.rs
+++ b/syrillian/src/engine/core/object.rs
@@ -48,13 +48,19 @@ impl Deref for GameObjectId {
     type Target = GameObject;
 
     fn deref(&self) -> &GameObject {
-        World::instance().objects.get(*self).unwrap()
+        World::instance().objects.get(*self).unwrap_or_else(|| {
+            log::error!("An error was encountered while getting a deref of a GameObject");
+            std::process::exit(1);
+        })
     }
 }
 
 impl DerefMut for GameObjectId {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        World::instance().objects.get_mut(*self).unwrap()
+        World::instance().objects.get_mut(*self).unwrap_or_else(|| {
+            log::error!("An error was encountered while getting a mutable deref of a GameObject");
+            std::process::exit(1);
+        })
     }
 }
 

--- a/syrillian/src/engine/core/object_extensions.rs
+++ b/syrillian/src/engine/core/object_extensions.rs
@@ -73,7 +73,12 @@ impl<'a> GOComponentExt<'a> for Collider3D {
 
     #[inline]
     fn build_component(&'a mut self, obj: &'a mut GameObject) -> Self::Outer {
-        let collider = self.get_collider_mut().expect("Collider should be created");
+        let collider = self.get_collider_mut().unwrap_or_else(|| {
+            log::error!(
+                "getting a mutable ref to a Collider returned None while trying to build_component. Collider should be created"
+            );
+            std::process::exit(1);
+        });
         GOColliderExt(collider, obj)
     }
 
@@ -118,7 +123,12 @@ impl<'a> GOComponentExt<'a> for RigidBodyComponent {
 
     #[inline]
     fn build_component(&'a mut self, obj: &'a mut GameObject) -> Self::Outer {
-        let rb = self.get_body_mut().expect("Rigid Body should be created");
+        let rb = self.get_body_mut().unwrap_or_else(|| {
+            log::error!(
+                "getting a mutable ref to a Rigid Body while trying to build_component returned None. Rigid Body should be created"
+            );
+            std::process::exit(1);
+        });
         GORigidBodyExt(rb, obj)
     }
 

--- a/syrillian/src/engine/input/gamepad_manager.rs
+++ b/syrillian/src/engine/input/gamepad_manager.rs
@@ -14,11 +14,17 @@ pub struct GamePadManager {
 impl Default for GamePadManager {
     fn default() -> Self {
         //let poller = Gilrs::new().expect("Init gamepad input failed");
-        let poller = GilrsBuilder::new()
+        let poller = match GilrsBuilder::new()
             .add_env_mappings(true)
             .add_included_mappings(false)
             .build()
-            .unwrap();
+        {
+            Ok(g) => g,
+            Err(err) => {
+                log::error!("An error was in creating a Gilrs : {}", err);
+                std::process::exit(1);
+            }
+        };
 
         Self {
             poller,

--- a/syrillian/src/engine/prefabs/first_person_player.rs
+++ b/syrillian/src/engine/prefabs/first_person_player.rs
@@ -30,8 +30,10 @@ impl Prefab for FirstPersonPlayerPrefab {
 
         char_controller
             .add_component::<Collider3D>()
-            .get_collider_mut()
-            .unwrap()
+            .get_collider_mut().unwrap_or_else(||{
+                log::error!("Failed to get_collider_mut in the char_controller");
+                std::process::exit(1);
+            })
             .set_shape(SharedShape::capsule_y(1.0, 0.25));
 
         if let Some(rigid_body) = char_controller

--- a/syrillian/src/engine/rendering/cache/asset_cache.rs
+++ b/syrillian/src/engine/rendering/cache/asset_cache.rs
@@ -51,8 +51,11 @@ impl AssetCache {
 
     pub fn mesh_unit_square(&self) -> Arc<RuntimeMesh> {
         self.meshes
-            .try_get(HMesh::UNIT_SQUARE, self)
-            .expect("Unit square is a default mesh")
+            .try_get(HMesh::UNIT_SQUARE, self).unwrap_or_else(||{
+                log::error!(
+                "Error while trying to get HMesh::UNIT_SQUARE from meshes : Unit square is a default mesh");
+                std::process::exit(1);
+            })
     }
 
     pub fn shader(&self, handle: HShader) -> Arc<RuntimeShader> {
@@ -95,45 +98,68 @@ impl AssetCache {
     }
 
     pub fn bgl_empty(&self) -> Arc<BindGroupLayout> {
-        self.bgls
-            .try_get(HBGL::EMPTY, self)
-            .expect("Light is a default layout")
+        self.bgls.try_get(HBGL::EMPTY, self).unwrap_or_else(|| {
+            log::error!(
+                "Failed while trying to get HBGL::EMPTY from bgls : Light is a default layout"
+            );
+            std::process::exit(1);
+        })
     }
 
     pub fn bgl_model(&self) -> Arc<BindGroupLayout> {
-        self.bgls
-            .try_get(HBGL::MODEL, self)
-            .expect("Model is a default layout")
+        self.bgls.try_get(HBGL::MODEL, self).unwrap_or_else(|| {
+            log::error!(
+                "Failed while trying to get HBGL::MODEL from bgls : Model is a default layout"
+            );
+            std::process::exit(1);
+        })
     }
 
     pub fn bgl_render(&self) -> Arc<BindGroupLayout> {
-        self.bgls
-            .try_get(HBGL::RENDER, self)
-            .expect("Render is a default layout")
+        self.bgls.try_get(HBGL::RENDER, self).unwrap_or_else(|| {
+            log::error!(
+                "Failed while trying to get HBGL::RENDER from bgls : Render is a default layout"
+            );
+            std::process::exit(1);
+        })
     }
 
     pub fn bgl_light(&self) -> Arc<BindGroupLayout> {
-        self.bgls
-            .try_get(HBGL::LIGHT, self)
-            .expect("Light is a default layout")
+        self.bgls.try_get(HBGL::LIGHT, self).unwrap_or_else(|| {
+            log::error!(
+                "Failed while trying to get HBGL::EMPTY from bgls : Light is a default layout"
+            );
+            std::process::exit(1);
+        })
     }
 
     pub fn bgl_shadow(&self) -> Arc<BindGroupLayout> {
-        self.bgls
-            .try_get(HBGL::SHADOW, self)
-            .expect("Shadow is a default layout")
+        self.bgls.try_get(HBGL::SHADOW, self).unwrap_or_else(|| {
+            log::error!(
+                "Failed while trying to get HBGL::SHADOW from bgls : Shadow is a default layout"
+            );
+            std::process::exit(1);
+        })
     }
 
     pub fn bgl_material(&self) -> Arc<BindGroupLayout> {
-        self.bgls
-            .try_get(HBGL::MATERIAL, self)
-            .expect("Material is a default layout")
+        self.bgls.try_get(HBGL::MATERIAL, self).unwrap_or_else(|| {
+            log::error!(
+                "Failed while trying to get HBGL::MATERIAL from bgls : Material is a default layout"
+            );
+            std::process::exit(1);
+        })
     }
 
     pub fn bgl_post_process(&self) -> Arc<BindGroupLayout> {
         self.bgls
             .try_get(HBGL::POST_PROCESS, self)
-            .expect("Post Process is a default layout")
+            .unwrap_or_else(|| {
+                log::error!(
+                    "Failed while trying to get HBGL::POST_PROCESS from bgls : Post Process is a default layout"
+                );
+                std::process::exit(1);
+            })
     }
 
     pub fn font(&self, handle: HFont) -> Arc<FontAtlas> {
@@ -149,12 +175,18 @@ impl AssetCache {
         refreshed_count += self.textures.refresh_dirty();
         refreshed_count += self.bgls.refresh_dirty();
 
-        *self.last_refresh.lock().unwrap() = Instant::now();
+        *self.last_refresh.lock().unwrap_or_else(|_|{
+            log::error!("Failed to get a Mutex to last_refresh to set it to Instant now");
+            std::process::exit(1);
+        }) = Instant::now();
 
         refreshed_count
     }
 
     pub fn last_refresh(&self) -> Instant {
-        *self.last_refresh.lock().unwrap()
+        *self.last_refresh.lock().unwrap_or_else(|_|{
+            log::error!("Failed to get a Mutex to last_refresh to return it as an Instant");
+            std::process::exit(1);
+        }) 
     }
 }

--- a/syrillian/src/engine/rendering/debug_renderer.rs
+++ b/syrillian/src/engine/rendering/debug_renderer.rs
@@ -34,7 +34,13 @@ impl DebugRenderer {
     }
 
     pub fn next_mode() -> u32 {
-        let mut inner = DEBUG_RENDERER.write().unwrap();
+        let mut inner = DEBUG_RENDERER.write().unwrap_or_else(|e| {
+            log::error!(
+                "Failed to get a writable inner to DEBUG_RENDERER in next_mode : {}",
+                e
+            );
+            std::process::exit(1);
+        });
         if inner.mesh_edges && !inner.vertex_normals {
             inner.vertex_normals = true;
             1
@@ -61,37 +67,79 @@ impl DebugRenderer {
 
     // TODO: Turn these into a macro
     pub fn mesh_edges() -> bool {
-        let inner = DEBUG_RENDERER.read().unwrap();
+        let inner = DEBUG_RENDERER.read().unwrap_or_else(|e| {
+            log::error!(
+                "Failed to get a readable inner to DEBUG_RENDERER in mesh_edges : {}",
+                e
+            );
+            std::process::exit(1);
+        });
         inner.mesh_edges
     }
 
     pub fn collider_mesh() -> bool {
-        let inner = DEBUG_RENDERER.read().unwrap();
+        let inner = DEBUG_RENDERER.read().unwrap_or_else(|e| {
+            log::error!(
+                "Failed to get a readable inner to DEBUG_RENDERER in collider_mesh : {}",
+                e
+            );
+            std::process::exit(1);
+        });
         inner.colliders_edges
     }
 
     pub fn mesh_vertex_normals() -> bool {
-        let inner = DEBUG_RENDERER.read().unwrap();
+        let inner = DEBUG_RENDERER.read().unwrap_or_else(|e| {
+            log::error!(
+                "Failed to get a readable inner to DEBUG_RENDERER in mesh_vertex_normals : {}",
+                e
+            );
+            std::process::exit(1);
+        });
         inner.vertex_normals
     }
 
     pub fn physics_rays() -> bool {
-        let inner = DEBUG_RENDERER.read().unwrap();
+        let inner = DEBUG_RENDERER.read().unwrap_or_else(|e| {
+            log::error!(
+                "Failed to get a readable inner to DEBUG_RENDERER in physics_rays : {}",
+                e
+            );
+            std::process::exit(1);
+        });
         inner.rays
     }
 
     pub fn text_geometry() -> bool {
-        let inner = DEBUG_RENDERER.read().unwrap();
+        let inner = DEBUG_RENDERER.read().unwrap_or_else(|e| {
+            log::error!(
+                "Failed to get a readable inner to DEBUG_RENDERER in text_geometry : {}",
+                e
+            );
+            std::process::exit(1);
+        });
         inner.text_geometry
     }
 
     pub fn light() -> bool {
-        let inner = DEBUG_RENDERER.read().unwrap();
+        let inner = DEBUG_RENDERER.read().unwrap_or_else(|e| {
+            log::error!(
+                "Failed to get a readable inner to DEBUG_RENDERER in light : {}",
+                e
+            );
+            std::process::exit(1);
+        });
         inner.light
     }
 
     pub fn off() {
-        let mut inner = DEBUG_RENDERER.write().unwrap();
+        let mut inner = DEBUG_RENDERER.write().unwrap_or_else(|e| {
+            log::error!(
+                "Failed to get a writable inner to DEBUG_RENDERER in off : {}",
+                e
+            );
+            std::process::exit(1);
+        });
         *inner = DebugRenderer {
             mesh_edges: false,
             vertex_normals: false,

--- a/syrillian/src/engine/rendering/light_manager.rs
+++ b/syrillian/src/engine/rendering/light_manager.rs
@@ -121,7 +121,13 @@ impl LightManager {
 
         let shadow_texture =
             Texture::new_2d_shadow_map_array(8, 1024, 1024).store(&cache.textures.store());
-        let texture = cache.textures.try_get(shadow_texture, cache).unwrap();
+        let texture = cache
+            .textures
+            .try_get(shadow_texture, cache)
+            .unwrap_or_else(|| {
+                log::error!("Failed to get a Texture in light_for_layer in the LightManager");
+                std::process::exit(1);
+            });
 
         let bgl = cache.bgl_light();
         let count: u32 = 0;
@@ -186,7 +192,10 @@ impl LightManager {
         use crate::assets::HShader;
         use wgpu::ShaderStages;
 
-        let mut pass = ctx.pass.write().unwrap();
+        let mut pass = ctx.pass.write().unwrap_or_else(|_| {
+            log::error!("Failed to obtain a writable pass in render_debug_lights in LightManager");
+            std::process::exit(1);
+        });
 
         let shader = renderer.cache.shader(HShader::DEBUG_LIGHT);
         crate::must_pipeline!(pipeline = shader, ctx.pass_type => return);

--- a/syrillian/src/engine/rendering/proxies/debug_proxy.rs
+++ b/syrillian/src/engine/rendering/proxies/debug_proxy.rs
@@ -173,7 +173,10 @@ impl DebugSceneProxy {
             return;
         };
 
-        let mut pass = ctx.pass.write().unwrap();
+        let mut pass = ctx.pass.write().unwrap_or_else(|_| {
+            log::error!("Failed to obtain a writable pass in render_lines in the debug_proxy");
+            std::process::exit(1);
+        });
 
         pass.set_vertex_buffer(0, line_buffer.slice(..));
 
@@ -204,7 +207,10 @@ impl DebugSceneProxy {
             let shader = cache.shader(HShader::DEBUG_EDGES);
             must_pipeline!(pipeline = shader, ctx.pass_type => return);
 
-            let mut pass = ctx.pass.write().unwrap();
+            let mut pass = ctx.pass.write().unwrap_or_else(|_| {
+                log::error!("Failed to obtain a writable pass in render_meshes in the debug_proxy");
+                std::process::exit(1);
+            });
 
             pass.set_pipeline(pipeline);
             pass.set_push_constants(ShaderStages::FRAGMENT, 0, bytemuck::bytes_of(&self.color));

--- a/syrillian/src/engine/rendering/proxies/image.rs
+++ b/syrillian/src/engine/rendering/proxies/image.rs
@@ -68,7 +68,10 @@ impl SceneProxy for ImageSceneProxy {
         let material = renderer.cache.material(self.material);
         let shader = renderer.cache.shader_2d();
 
-        let mut pass = ctx.pass.write().unwrap();
+        let mut pass = ctx.pass.write().unwrap_or_else(|_| {
+            log::error!("Failed to obtain a writable pass in render in image.rs");
+            std::process::exit(1);
+        });
 
         pass.set_pipeline(shader.solid_pipeline());
 

--- a/syrillian/src/engine/rendering/proxies/mesh_proxy.rs
+++ b/syrillian/src/engine/rendering/proxies/mesh_proxy.rs
@@ -89,7 +89,10 @@ impl SceneProxy for MeshSceneProxy {
             return;
         };
 
-        let mut pass = ctx.pass.write().unwrap();
+        let mut pass = ctx.pass.write().unwrap_or_else(|_| {
+            log::error!("Failed to obtain a writable pass in render in mesh_proxy.rs");
+            std::process::exit(1);
+        });
 
         pass.set_bind_group(1, data.uniform.bind_group(), &[]);
 

--- a/syrillian/src/engine/rendering/proxies/text_proxy.rs
+++ b/syrillian/src/engine/rendering/proxies/text_proxy.rs
@@ -183,7 +183,10 @@ impl<const D: u8, DIM: TextDim<D>> TextProxy<D, DIM> {
         let shader = cache.shader(DIM::shader());
         let material = cache.material(font.atlas());
 
-        let mut pass = pass.write().unwrap();
+        let mut pass = pass.write().unwrap_or_else(|_| {
+            log::error!("Failed to obtain a writable pass in render in text_proxy.rs");
+            std::process::exit(1);
+        });
         must_pipeline!(pipeline = shader, ctx.pass_type => return);
 
         pass.set_pipeline(pipeline);

--- a/syrillian/src/engine/rendering/renderer.rs
+++ b/syrillian/src/engine/rendering/renderer.rs
@@ -256,7 +256,10 @@ impl Renderer {
         let shadow_layers = self
             .lights
             .shadow_array(self.cache.textures.store())
-            .unwrap()
+            .unwrap_or_else(|| {
+                log::error!("Failed to obtain a shadow_array from the LightManager");
+                std::process::exit(1);
+            })
             .array_layers;
         let light_count = self.lights.update_shadow_map_ids(shadow_layers);
 

--- a/syrillian/src/engine/rendering/state.rs
+++ b/syrillian/src/engine/rendering/state.rs
@@ -66,9 +66,10 @@ impl State {
                 ..RequestAdapterOptions::default()
             })
             .await
-            .expect(
-                "Couldn't find anything that supports rendering stuff. How are you reading this..?",
-            )
+            .unwrap_or_else(|_| {
+                log::error!("Couldn't an adapter that supports rendering. How are you reading this..? is indeed a vaild question.");
+                std::process::exit(1);
+            })
     }
 
     // wgpu tracing is currently unavailable

--- a/syrillian/src/engine/rendering/uniform.rs
+++ b/syrillian/src/engine/rendering/uniform.rs
@@ -172,7 +172,9 @@ impl<I: ShaderUniformMultiIndex> ShaderUniform<I> {
     pub fn buffer(&self, idx: I) -> &Buffer {
         self.buffers.buffers[idx.index()]
             .as_ref()
-            .expect("Requested a binding resource that isn't a buffer")
+            .unwrap_or_else(|| { log::error!("Failed to get a ref to a MultiIndex buffer to impl ShaderUniform it's very likely that: a binding resource was requested but it's not a buffer");
+                std::process::exit(1);
+            })
     }
 }
 
@@ -181,7 +183,10 @@ impl<I: ShaderUniformSingleIndex> ShaderUniform<I> {
     pub fn buffer_one(&self) -> &Buffer {
         self.buffers.buffers[0]
             .as_ref()
-            .expect("Requested a binding resource that isn't a buffer")
+            .unwrap_or_else(|| { 
+                log::error!("Failed to get a ref to a SingleIndex buffer to impl ShaderUniform it's very likely that: a binding resource was requested but it's not a buffer");
+                std::process::exit(1);
+            })
     }
 }
 
@@ -235,7 +240,9 @@ impl<I: ShaderUniformIndex> ResourceDesc<'_, I> {
             | ResourceDesc::StorageBufferData { .. }
             | ResourceDesc::EmptyBuffer { .. } => buffers.buffers[self.index()]
                 .as_ref()
-                .expect("Resource should be registered as a buffer")
+                .unwrap_or_else(||{
+                    log::error!("Failed to get a ResourceDesc::EmptyBufferResource buffer as a ref in entry uniform.rs : should be registered as a buffer");
+                    std::process::exit(1);})
                 .as_entire_binding(),
             ResourceDesc::TextureView { view, .. } => BindingResource::TextureView(view),
             ResourceDesc::Sampler { sampler, .. } => BindingResource::Sampler(sampler),

--- a/syrillian/src/lib.rs
+++ b/syrillian/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(clippy::unwrap_used)]
+#![deny(clippy::expect_used)]
 pub mod engine;
 pub mod utils;
 pub mod windowing;

--- a/syrillian/src/utils/animation.rs
+++ b/syrillian/src/utils/animation.rs
@@ -87,7 +87,10 @@ fn find_key(times: &[f32], t: f32) -> usize {
     if t <= times[0] {
         return 0;
     }
-    if t >= *times.last().unwrap() {
+    if t >= *times.last().unwrap_or_else(|| {
+        log::error!("Failed to get times.last() in find_key in animation.rs");
+        std::process::exit(1);
+    }) {
         return times.len() - 1;
     }
     times

--- a/syrillian/src/utils/hacks.rs
+++ b/syrillian/src/utils/hacks.rs
@@ -19,7 +19,12 @@ impl<K: slotmap::Key, V> DenseSlotMapDirectAccess<V> for DenseSlotMap<K, V> {
         // - DenseSlotMap is dense: len == values.len()
         // - internal Vec<V> storage is contiguous
         unsafe {
-            let first: *const V = self.values().next().unwrap();
+            let first: *const V = self.values().next().unwrap_or_else(|| {
+                log::error!(
+                    "failed to cast self.values.next() to a const ptr of V in DenseSlotMap in hacks.rs"
+                );
+                std::process::exit(1);
+            });
             slice::from_raw_parts(first, len)
         }
     }


### PR DESCRIPTION
## What is this PR request
This PR introduces an **early support** for migrating away from using `unwrap` and `expect` in favor of safer and more maintainable error-handling approaches.  
It diracted towards achieving a full solution that addresses **[#65](https://github.com/Kek5chen/syrillian/issues/65) – "Keep panic usage as low as possible"**.

The main goal is to **log and exit gracefully** for critical errors instead of panicking.  
Later improvements will aim to provide **safety nets** and **graceful recovery mechanisms** without exiting where ***appropriate***.

---

## Changes Made  
- **Banned** `unwrap` and `expect` using **Clippy** lint rules.
- Replaced empty unwraps with more ****infromative**** alternatives:
  - ✅ Use a mix of `match` statements or `unwrap_or_else(...)` where recovery is appropriate.
- Leveraged the **`error!` macro** from the logging system to **log critical failures**.
- Ensured the application **exits gracefully** rather than panicking.
- Set the foundation for future enhancements where **non-exiting error handling** will be supported.
- **Banned** `unwrap` and `expect` by adding Clippy lint macros in  
  `syrillian/syrillian/src/lib.rs`:

  ```rust
  #![deny(clippy::unwrap_used)]
  #![deny(clippy::expect_used)]
---

## Why  
- it Establishes **a simple baseline** for future, more resilient error-handling strategies.
---
## Feel free to discuss it with me for any changes
