### PR TITLE
fix: resolve GitHub Actions cache conflicts in matrix builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,9 +41,9 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0
+        uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ${{ matrix.os }}
+          shared-key: ${{ matrix.os }}-${{ matrix.profile }}
 
       - name: Build and Test
         shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
         uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Cache Rust dependencies and tools
-        uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0
+        uses: Swatinem/rust-cache@v2
 
       - name: Check formatting
         run: cargo fmt --all -- --check


### PR DESCRIPTION
## Summary
This PR fixes the cache conflict errors (409 Conflict) that were occurring in our GitHub Actions CI workflows when multiple matrix jobs attempted to save to the same cache key simultaneously.

Just a small fix to make our CI happier! 🎯

### Problem
The CI was showing the following warnings across multiple OS environments:
 - `Failed to save: Failed to CreateCacheEntry: Received non-retryable error: Failed request: (409) Conflict: cache entry
  with the same key, version, and scope already exists`
 - Cache keys were not found initially but conflicted when saving
